### PR TITLE
early-exit optimization using a HEAD request to check for existence f…

### DIFF
--- a/src/scripts/save-cache.sh
+++ b/src/scripts/save-cache.sh
@@ -5,6 +5,16 @@ echo "Cache Path is $CACHE_PATH"
 # Check if the cache path exists
 if [ -d "$CACHE_PATH" ]; then
   
+  # Check if cache already exists in S3 before compressing
+  echo "Checking if cache already exists in S3..."
+  S3_OBJECT_PATH="s3://$BUCKET_NAME/$CACHE_KEY/$CACHE_KEY.tar.gz"
+  
+  if aws s3api head-object --bucket "$BUCKET_NAME" --key "$CACHE_KEY/$CACHE_KEY.tar.gz" > /dev/null 2>&1; then
+    echo "Cache key '$CACHE_KEY' already exists in S3. Skipping compression and upload."
+    exit 0
+  fi
+  
+  echo "Cache not found in S3. Proceeding with compression..."
   echo "Cache path exists. Archiving..."
   # Create the archive
   tar -czf "$CACHE_KEY.tar.gz" "$CACHE_PATH"
@@ -21,7 +31,7 @@ if [ -d "$CACHE_PATH" ]; then
   aws configure set default.s3.multipart_threshold "$S3_MULTIPART_THRESHOLD"
 
   # Upload the archive to the S3 bucket
-  aws s3 cp "$CACHE_KEY.tar.gz" "s3://$BUCKET_NAME/$CACHE_KEY/$CACHE_KEY.tar.gz"
+  aws s3 cp "$CACHE_KEY.tar.gz" "$S3_OBJECT_PATH"
   echo "Cache archive uploaded to S3."
 else
   echo "Cache path does not exist. Skipping upload."


### PR DESCRIPTION
Missing Early-Exit Optimization

CircleCI’s native save_cache checks if the key already exists before recompressing. The S3 orb always creates the archive  even if it already exists in the bucket. That’s wasted time.

Would be great to implement:

HEAD request to check existence before compressing

If exists > skip compression/upload


HEAD Request Check: 

- Before compressing anything, the script now performs a aws s3api head-object call to check if the cache already exists in S3

Early Exit: If the object exists, it prints a message and exits with success (0), skipping:

- The expensive tar compression step
- S3 configuration
- The upload operation

Proceed if Missing: 

- Only if the cache doesn't exist will it proceed with compression and upload